### PR TITLE
Fix an overflow addition

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -2504,6 +2504,20 @@ pub fn card_from_str(s: &str) -> Result<u8, String> {
     Ok(result)
 }
 
+/// Attempts to read the next card from a char iterator.
+///
+/// Card ID: `"2c"` => `0`, `"2d"` => `1`, `"2h"` => `2`, ..., `"As"` => `51`.
+///
+/// # Examples
+/// ```
+/// use postflop_solver::card_from_chars;
+///
+/// let mut chars = "2c3d4hAs".chars();
+/// assert_eq!(card_from_chars(&mut chars), Ok(0));
+/// assert_eq!(card_from_chars(&mut chars), Ok(5));
+/// assert_eq!(card_from_chars(&mut chars), Ok(10));
+/// assert_eq!(card_from_chars(&mut chars), Ok(51));
+/// ```
 #[inline]
 pub fn card_from_chars<T: Iterator<Item = char>>(chars: &mut T) -> Result<u8, String> {
     let rank_char = chars.next().ok_or_else(|| "parse failed".to_string())?;

--- a/src/game.rs
+++ b/src/game.rs
@@ -1364,35 +1364,36 @@ impl PostFlopGame {
             }
 
             let raise_candidates = &candidates[player_opponent as usize].raise;
-            if raise_candidates.len() > 0 {
-                let mut min_opponent_ratio = f32::MAX;
-                for &bet_size in raise_candidates {
-                    match bet_size {
-                        BetSize::PotRelative(ratio) => {
-                            min_opponent_ratio = min_opponent_ratio.min(ratio);
-                        }
-                        BetSize::LastBetRelative(ratio) => {
-                            let pot_ratio = size as f32 * (ratio - 1.0) / new_pot as f32;
-                            min_opponent_ratio = min_opponent_ratio.min(pot_ratio);
-                        }
+            if raise_candidates.len() == 0 {
+                return size;
+            }
+
+            let mut min_opponent_ratio = f32::MAX;
+            for &bet_size in raise_candidates {
+                match bet_size {
+                    BetSize::PotRelative(ratio) => {
+                        min_opponent_ratio = min_opponent_ratio.min(ratio);
+                    }
+                    BetSize::LastBetRelative(ratio) => {
+                        let pot_ratio = size as f32 * (ratio - 1.0) / new_pot as f32;
+                        min_opponent_ratio = min_opponent_ratio.min(pot_ratio);
                     }
                 }
-                let min_opponent_bet = size + (new_pot as f32 * min_opponent_ratio).round() as i32;
-                let next_bet_diff = min_opponent_bet - size;
-                let next_pot = new_pot + 2 * next_bet_diff;
+            }
+            let min_opponent_bet = size + (new_pot as f32 * min_opponent_ratio).round() as i32;
+            let next_bet_diff = min_opponent_bet - size;
+            let next_pot = new_pot + 2 * next_bet_diff;
 
-                let threshold =
-                    (next_pot as f32 * self.config.force_all_in_threshold).round() as i32;
-                if max_bet <= min_opponent_bet + threshold {
-                    // next opponent bet will be always all-in
-                    let ratio = new_bet_diff as f32 / pot as f32;
-                    let a = 2.0 * pot as f32 * ratio * min_opponent_ratio;
-                    let b = pot as f32 * (ratio + min_opponent_ratio);
-                    let c = (max_bet - opponent_bet) as f32;
-                    // solve quadratic equation
-                    let coef = ((4.0 * a * c + b * b).sqrt() - b) / (2.0 * a);
-                    return opponent_bet + (new_bet_diff as f32 * coef).round() as i32;
-                }
+            let threshold = (next_pot as f32 * self.config.force_all_in_threshold).round() as i32;
+            if max_bet <= min_opponent_bet + threshold {
+                // next opponent bet will be always all-in
+                let ratio = new_bet_diff as f32 / pot as f32;
+                let a = 2.0 * pot as f32 * ratio * min_opponent_ratio;
+                let b = pot as f32 * (ratio + min_opponent_ratio);
+                let c = (max_bet - opponent_bet) as f32;
+                // solve quadratic equation
+                let coef = ((4.0 * a * c + b * b).sqrt() - b) / (2.0 * a);
+                return opponent_bet + (new_bet_diff as f32 * coef).round() as i32;
             }
 
             size

--- a/src/game.rs
+++ b/src/game.rs
@@ -1363,33 +1363,36 @@ impl PostFlopGame {
                 return size;
             }
 
-            let mut min_opponent_ratio = f32::MAX;
-            for &bet_size in &candidates[player_opponent as usize].raise {
-                match bet_size {
-                    BetSize::PotRelative(ratio) => {
-                        min_opponent_ratio = min_opponent_ratio.min(ratio);
-                    }
-                    BetSize::LastBetRelative(ratio) => {
-                        let pot_ratio = size as f32 * (ratio - 1.0) / new_pot as f32;
-                        min_opponent_ratio = min_opponent_ratio.min(pot_ratio);
+            let raise_candidates = &candidates[player_opponent as usize].raise;
+            if raise_candidates.len() > 0 {
+                let mut min_opponent_ratio = f32::MAX;
+                for &bet_size in raise_candidates {
+                    match bet_size {
+                        BetSize::PotRelative(ratio) => {
+                            min_opponent_ratio = min_opponent_ratio.min(ratio);
+                        }
+                        BetSize::LastBetRelative(ratio) => {
+                            let pot_ratio = size as f32 * (ratio - 1.0) / new_pot as f32;
+                            min_opponent_ratio = min_opponent_ratio.min(pot_ratio);
+                        }
                     }
                 }
-            }
+                let min_opponent_bet = size + (new_pot as f32 * min_opponent_ratio).round() as i32;
+                let next_bet_diff = min_opponent_bet - size;
+                let next_pot = new_pot + 2 * next_bet_diff;
 
-            let min_opponent_bet = size + (new_pot as f32 * min_opponent_ratio).round() as i32;
-            let next_bet_diff = min_opponent_bet - size;
-            let next_pot = new_pot + 2 * next_bet_diff;
-
-            let threshold = (next_pot as f32 * self.config.force_all_in_threshold).round() as i32;
-            if max_bet <= min_opponent_bet + threshold {
-                // next opponent bet will be always all-in
-                let ratio = new_bet_diff as f32 / pot as f32;
-                let a = 2.0 * pot as f32 * ratio * min_opponent_ratio;
-                let b = pot as f32 * (ratio + min_opponent_ratio);
-                let c = (max_bet - opponent_bet) as f32;
-                // solve quadratic equation
-                let coef = ((4.0 * a * c + b * b).sqrt() - b) / (2.0 * a);
-                return opponent_bet + (new_bet_diff as f32 * coef).round() as i32;
+                let threshold =
+                    (next_pot as f32 * self.config.force_all_in_threshold).round() as i32;
+                if max_bet <= min_opponent_bet + threshold {
+                    // next opponent bet will be always all-in
+                    let ratio = new_bet_diff as f32 / pot as f32;
+                    let a = 2.0 * pot as f32 * ratio * min_opponent_ratio;
+                    let b = pot as f32 * (ratio + min_opponent_ratio);
+                    let c = (max_bet - opponent_bet) as f32;
+                    // solve quadratic equation
+                    let coef = ((4.0 * a * c + b * b).sqrt() - b) / (2.0 * a);
+                    return opponent_bet + (new_bet_diff as f32 * coef).round() as i32;
+                }
             }
 
             size

--- a/src/game.rs
+++ b/src/game.rs
@@ -2504,7 +2504,7 @@ pub fn card_from_str(s: &str) -> Result<u8, String> {
 }
 
 #[inline]
-fn card_from_chars<T: Iterator<Item = char>>(chars: &mut T) -> Result<u8, String> {
+pub fn card_from_chars<T: Iterator<Item = char>>(chars: &mut T) -> Result<u8, String> {
     let rank_char = chars.next().ok_or_else(|| "parse failed".to_string())?;
     let suit_char = chars.next().ok_or_else(|| "parse failed".to_string())?;
 


### PR DESCRIPTION
If there are no raise candidates, `min_opponent_ratio` is left with its initial value of `f32::MAX`, which then causes an overflow when evaluating `size + (new_pot * min_opponent_ratio)`.

Also card_from_chars is now public.