### PR TITLE
Add Donk Sizings for turn and river

### DIFF
--- a/src/bet_size.rs
+++ b/src/bet_size.rs
@@ -41,7 +41,7 @@ pub struct BetSizeCandidates {
 /// let donk_size = DonkSizeCandidates::try_from("50%, 150%").unwrap();
 ///
 /// assert_eq!(donk_size.donk, vec![PotRelative(0.5), PotRelative(1.5)]);
-/// 
+///
 /// ```
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "bincode", derive(Decode, Encode))]
@@ -73,7 +73,7 @@ impl TryFrom<&str> for DonkSizeCandidates {
     /// let donk_size = DonkSizeCandidates::try_from("50%, 150%").unwrap();
     ///
     /// assert_eq!(donk_size.donk, vec![PotRelative(0.5), PotRelative(1.5)]);
-    /// 
+    ///
     /// ```
     fn try_from(donk_str: &str) -> Result<Self, Self::Error> {
         let donk_string = TRIM_REGEX.replace_all(donk_str, "$1").trim().to_string();

--- a/src/game.rs
+++ b/src/game.rs
@@ -2494,7 +2494,6 @@ mod tests {
     use super::*;
     use crate::solver::*;
 
-    
     #[cfg(feature = "bincode")]
     use std::fs::File;
     #[cfg(feature = "bincode")]
@@ -2798,13 +2797,13 @@ mod tests {
             game.memory_usage().0 as f64 / (1024.0 * 1024.0 * 1024.0)
         );
         game.allocate_memory(false);
-        
+
         game.play(0);
-        
+
         game.play(1);
-        
+
         game.play(1);
-        
+
         assert!(game.is_chance_node());
 
         let card = card_from_str("7s").unwrap();
@@ -2837,7 +2836,5 @@ mod tests {
         println!("Available actions: {:?}", actions); // [Fold, Call, Raise(300)]
 
         assert!(matches!(game.available_actions()[1], Bet(232)));
-
-
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -123,6 +123,8 @@ unsafe impl Sync for PostFlopNode {}
 ///     flop_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 ///     turn_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 ///     river_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
+///     turn_donk_sizes: [bet_sizes.clone(), bet_sizes.clone()],
+///    river_donk_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 ///     add_all_in_threshold: 1.2,
 ///     force_all_in_threshold: 0.1,
 ///     adjust_last_two_bet_sizes: true,

--- a/src/game.rs
+++ b/src/game.rs
@@ -214,7 +214,7 @@ struct BuildTreeInfo<'a> {
     num_storage_elements: &'a AtomicU64,
     stack_size: [usize; 2],
     max_stack_size: &'a [AtomicUsize; 2],
-    last_aggressor: i32
+    last_aggressor: i32,
 }
 
 const PLAYER_OOP: u16 = 0;
@@ -1034,7 +1034,7 @@ impl PostFlopGame {
             num_storage_elements: &num_storage_elements,
             stack_size: [0, 0],
             max_stack_size: &max_stack_size,
-            last_aggressor: -1
+            last_aggressor: -1,
         };
 
         let mut root = self.root();
@@ -1140,7 +1140,6 @@ impl PostFlopGame {
             }
 
             for (action, child) in node.actions.iter().zip(node.children.iter()) {
-                
                 self.build_tree_recursive(
                     &mut child.lock(),
                     &BuildTreeInfo {
@@ -1182,7 +1181,7 @@ impl PostFlopGame {
                     _ => {}
                 }
                 //if the current nodes player is calling, this means that the last aggressor must be the other player
-                if matches!(action, Action::Call){
+                if matches!(action, Action::Call) {
                     self.build_tree_recursive(
                         &mut child.lock(),
                         &BuildTreeInfo {
@@ -1194,7 +1193,7 @@ impl PostFlopGame {
                             ..*info
                         },
                     )
-                }else{
+                } else {
                     self.build_tree_recursive(
                         &mut child.lock(),
                         &BuildTreeInfo {
@@ -1291,19 +1290,19 @@ impl PostFlopGame {
 
         let (candidates, is_river) = if node.turn == NOT_DEALT {
             (&self.config.flop_bet_sizes, false)
-
-        }else if node.river == NOT_DEALT && matches!(
-            info.last_action,
-            Action::Chance(_)
-        ) && player == PLAYER_OOP && info.last_aggressor == player_opponent as i32{
+        } else if node.river == NOT_DEALT
+            && matches!(info.last_action, Action::Chance(_))
+            && player == PLAYER_OOP
+            && info.last_aggressor == player_opponent as i32
+        {
             //Turn sizings for the oop player if they were not the last aggressor, also called a donk bet.
             (&self.config.turn_donk_sizes, false)
         } else if node.river == NOT_DEALT {
             (&self.config.turn_bet_sizes, false)
-        } else if matches!(
-            info.last_action,
-            Action::Chance(_)
-        ) && player == PLAYER_OOP && info.last_aggressor == player_opponent as i32 {
+        } else if matches!(info.last_action, Action::Chance(_))
+            && player == PLAYER_OOP
+            && info.last_aggressor == player_opponent as i32
+        {
             //Turn sizings for the oop player if they were not the last aggressor, also called a donk bet.
             (&self.config.river_donk_sizes, true)
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 //! let oop_range = "66+,A8s+,A5s-A4s,AJo+,K9s+,KQo,QTs+,JTs,96s+,85s+,75s+,65s,54s";
 //! let ip_range = "QQ-22,AQs-A2s,ATo+,K5s+,KJo+,Q8s+,J8s+,T7s+,96s+,86s+,75s+,64s+,53s+";
 //! let bet_sizes = BetSizeCandidates::try_from(("50%", "50%")).unwrap();
+//! let donk_sizes = DonkSizeCandidates::try_from("50%, 150%").unwrap();
+//! 
 //! let config = GameConfig {
 //!     flop: flop_from_str("Td9d6h").unwrap(),
 //!     turn: card_from_str("Qh").unwrap(),
@@ -18,8 +20,8 @@
 //!     flop_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 //!     turn_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 //!     river_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
-//!     turn_donk_sizes: [bet_sizes.clone(), bet_sizes.clone()],
-//!     river_donk_sizes: [bet_sizes.clone(), bet_sizes.clone()],
+//!     turn_donk_sizes: Some(donk_sizes.clone()),
+//!     river_donk_sizes: Some(donk_sizes.clone()),
 //!     add_all_in_threshold: 1.2,
 //!     force_all_in_threshold: 0.1,
 //!     adjust_last_two_bet_sizes: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //!     flop_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 //!     turn_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 //!     river_bet_sizes: [bet_sizes.clone(), bet_sizes.clone()],
+//!     turn_donk_sizes: [bet_sizes.clone(), bet_sizes.clone()],
+//!     river_donk_sizes: [bet_sizes.clone(), bet_sizes.clone()],
 //!     add_all_in_threshold: 1.2,
 //!     force_all_in_threshold: 0.1,
 //!     adjust_last_two_bet_sizes: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! let ip_range = "QQ-22,AQs-A2s,ATo+,K5s+,KJo+,Q8s+,J8s+,T7s+,96s+,86s+,75s+,64s+,53s+";
 //! let bet_sizes = BetSizeCandidates::try_from(("50%", "50%")).unwrap();
 //! let donk_sizes = DonkSizeCandidates::try_from("50%, 150%").unwrap();
-//! 
+//!
 //! let config = GameConfig {
 //!     flop: flop_from_str("Td9d6h").unwrap(),
 //!     turn: card_from_str("Qh").unwrap(),


### PR DESCRIPTION
Hi,

In an effort to compare this solver with Pio and Jesolver (A third party solver that is much faster than pio) I decided to implement the donk sizing options that pio uses. If you want an example of this in action, check out [this](http://jeskola.net/jesolver_beta/newbench.html) page where oskari tammelin (a member of the alberta research group that solved limit holdem) compares his commercial solver Jesolver to piosolver. He uses [this](http://jeskola.net/jesolver_beta/BigTree.txt) file to create his tests, which uses donk sizes of 50% and 1000% on the turn, and only 1000%.

Adding this to your solver decreases the memory needed and provides a more accurate comparison to Jesolver and pio, as well as removing donk bets that most players (and solvers) will never use, but would take up lots of memory when using them in the solve.

Feel free to change anything about the code style/implementation to fit your style as I know that this is not the best way to achieve what I want.

Thanks!