### PR TITLE
Remove pot size from target_exploitability calculation

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -64,7 +64,7 @@ fn main() {
 
     // solve the game
     let max_num_iterations = 1000;
-    let target_exploitability = game.tree_config().starting_pot as f32 * 0.005; // 0.5% of the pot
+    let target_exploitability = 0.005; // 0.5% of the pot
     let exploitability = solve(&mut game, max_num_iterations, target_exploitability, true);
     println!("Exploitability: {:.2}", exploitability);
 

--- a/src/game/tests.rs
+++ b/src/game/tests.rs
@@ -1178,7 +1178,7 @@ fn solve_pio_preset_normal() {
     );
     game.allocate_memory(false);
 
-    solve(&mut game, 1000, 180.0 * 0.001, true);
+    solve(&mut game, 1000, 0.001, true);
 
     game.cache_normalized_weights();
     let weights_oop = game.normalized_weights(0);
@@ -1235,7 +1235,7 @@ fn solve_pio_preset_raked() {
     );
     game.allocate_memory(false);
 
-    solve(&mut game, 1000, 180.0 * 0.001, true);
+    solve(&mut game, 1000, 0.001, true);
 
     game.cache_normalized_weights();
     let weights_oop = game.normalized_weights(0);

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -57,13 +57,13 @@ pub fn solve<T: Game>(
     let mut root = game.root();
     let mut exploitability = compute_exploitability(game);
 
-    if print_progress {
-        print!("iteration: 0 / {max_num_iterations} ");
-        print!("(exploitability = {exploitability:.4e})");
-        io::stdout().flush().unwrap();
-    }
-
     for t in 0..max_num_iterations {
+        if print_progress {
+            print!("\riteration: {} / {} ", t + 1, max_num_iterations);
+            print!("(exploitability = {exploitability:.4e})");
+            io::stdout().flush().unwrap();
+        }
+        
         if exploitability <= target_exploitability {
             break;
         }
@@ -85,12 +85,6 @@ pub fn solve<T: Game>(
 
         if (t + 1) % 10 == 0 || t + 1 == max_num_iterations {
             exploitability = compute_exploitability(game);
-        }
-
-        if print_progress {
-            print!("\riteration: {} / {} ", t + 1, max_num_iterations);
-            print!("(exploitability = {exploitability:.4e})");
-            io::stdout().flush().unwrap();
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/b-inary/postflop-solver/issues/44